### PR TITLE
Removed disabling of the turbolinks event

### DIFF
--- a/app/assets/javascripts/md_simple_editor.js.coffee
+++ b/app/assets/javascripts/md_simple_editor.js.coffee
@@ -97,7 +97,6 @@ insertAtCaret = (areaId, text) ->
 
 initializeEditor = ->
   md_simple_editor()
-  $(document).off 'turbolinks:load page:load ready', initializeEditor
   $('.preview_md').click ->
     preview()
 


### PR DESCRIPTION
The editor should initialize after each page reload. So I removed the 'off' statement.